### PR TITLE
refactor: make MAX_INT_LENGTH definition more expressive

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ function createError(str) {
   return err;
 }
 
-var MAX_INT_LENGTH = 16; // max int in JS is 9007199254740992
+var MAX_INT_LENGTH = (Number.MAX_SAFE_INTEGER || 9007199254740991).toString().length; // 16
 var TYPE_UNDEF = '0';
 var TYPE_NUM = '1';
 var TYPE_STRING = '2';


### PR DESCRIPTION
Maybe this isn't worth merging because it doesn't add any features or fix any bugs. However, I think it's preferable to express as much as possible in code directly rather than relying on comments. Figured I'd suggest it for your consideration since I was looking through this code anyway.